### PR TITLE
FIX Accepted_Payment_Methods has a deprecated constructor

### DIFF
--- a/accepted-payment-methods.php
+++ b/accepted-payment-methods.php
@@ -185,9 +185,8 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 	// The widget
 	class Accepted_Payment_Methods extends WP_Widget {
 
-		function Accepted_Payment_Methods() {
-			// Instantiate the parent object
-			parent::__construct( false, 'WooCommerce Accepted Payment Methods' );
+		function __construct() {
+			parent::__construct(false, 'WooCommerce Accepted Payment Methods' );
 		}
 
 		function widget( $args, $instance ) {


### PR DESCRIPTION
When installing the plugin it shows the following activation error::

An error occurred while installing Woocommerce Accepted Payment Methods: El plugin ha generado una respuesta insesperada. Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; Accepted_Payment_Methods has a deprecated constructor in /site/wp-content/plugins/woocommerce-accepted-payment-methods/accepted-payment-methods.php on line 186

Info :

WordPress 5.2.2
PHP 7.2